### PR TITLE
Fixed EDHRec Enrichment, Refactor Conditionals + Name Formatting, Add Card Type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,11 @@ reference/last_download.json
 
 # Docker
 .docker/
-docker-compose.override.yml 
+docker-compose.override.yml
+
+
+# uv
+uv.lock
+pyproject.toml
+.python-version
+.envrc

--- a/main.py
+++ b/main.py
@@ -1,0 +1,6 @@
+def main():
+    print("Hello from commander-helper!")
+
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -1,6 +1,0 @@
-def main():
-    print("Hello from commander-helper!")
-
-
-if __name__ == "__main__":
-    main()

--- a/src/data/card_data_downloader.py
+++ b/src/data/card_data_downloader.py
@@ -3,8 +3,28 @@ import asyncio
 import aiohttp
 import unicodedata
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Optional, TypedDict, Any
 from datetime import datetime
+
+
+class CardRequiredFields(TypedDict):
+    """Required fields for a card."""
+
+    name: str
+    layout: str
+    type_line: str
+    oracle_text: str
+    legalities: dict[str, str]
+
+
+class Card(CardRequiredFields, total=False):
+    # Core Scryfall fields
+    card_faces: list[dict[str, Any]]
+    # Only present on some cards to link related parts:
+    all_parts: list[dict[str, Any]]
+    # Populated by your enrichment step:
+    edhrec_data: dict[str, Any]
+
 
 class CardDataDownloader:
     """Downloads and processes MTG card data from Scryfall."""
@@ -12,6 +32,13 @@ class CardDataDownloader:
     SCRYFALL_BULK_API = "https://api.scryfall.com/bulk-data"
     ORACLE_CARDS = "oracle_cards"
     EDHREC_BASE_URL = "https://json.edhrec.com/pages/commanders"
+    AVERAGE_DECK_BASE_URL = "https://json.edhrec.com/pages/average-decks"
+    BACKGROUND_COMMANDERS = []
+    BACKGROUNDS = []
+    PARTNERS = []
+    DOCTORS_COMPANIONS = []
+    DOCTORS_COMMANDERS = []
+    FRIENDS_FOREVER = []
 
     def __init__(self):
         """Initialize the downloader."""
@@ -46,7 +73,7 @@ class CardDataDownloader:
                 print(f"Error getting bulk data URL: {e}")
         return None
 
-    async def _download_cards(self, url: str) -> List[Dict]:
+    async def _download_cards(self, url: str) -> list[Card]:
         """Download and process card data from Scryfall."""
         async with aiohttp.ClientSession() as session:
             try:
@@ -63,11 +90,20 @@ class CardDataDownloader:
 
         # Handle one special case, the Æ and æ ligature which should be replaced with ae
         if 'æ' in nkfd or 'Æ' in nkfd:
-            nkfd = nkfd.replace('Æ', 'ae').replace('Æ', 'ae')
+            nkfd = nkfd.replace("æ", "ae").replace("Æ", "ae")
 
-        return nkfd.encode('ascii', 'ignore').decode('utf-8').replace(' ', '-').lower()
+        return (
+            nkfd.encode("ascii", "ignore")
+            .decode("utf-8")
+            .replace(" ", "-")
+            .replace(",", "")
+            .replace("'", "")
+            .lower()
+        )
 
-    async def _get_edhrec_data(self, session: aiohttp.ClientSession, card_name: str) -> Optional[Dict]:
+    async def _get_edhrec_data(
+        self, session: aiohttp.ClientSession, card_name: str
+    ) -> Optional[dict[str, Any]]:
         """Get EDHREC data for a card."""
         try:
             formatted_name = self._format_name_for_edhrec(card_name)
@@ -76,27 +112,20 @@ class CardDataDownloader:
             async with session.get(url) as response:
                 if response.status == 200:
                     data = await response.json()
-                    if 'cardlist' in data:
+                    data_dictionary = data["container"]["json_dict"]
+                    if data_dictionary["cardlists"]:
                         return {
-                            'rank': data.get('rank', 0),
-                            'synergies': data.get('synergies', []),
-                            'average_decks': data.get('average_decks', 0),
-                            'potential_decks': data.get('potential_decks', 0),
-                            'top_cards': [
-                                {
-                                    'name': card['name'],
-                                    'synergy': card.get('synergy', 0),
-                                    'inclusion_rate': card.get('num_decks', 0) / card.get('potential_decks', 1) if card.get('potential_decks', 0) > 0 else 0
-                                }
-                                for card in data['cardlist'][:10]  # Get top 10 cards
-                            ]
+                            "synergies": data_dictionary["cardlists"][1],
+                            "potential_decks": data_dictionary["card"].get(
+                                "potential_decks", 0
+                            ),
                         }
             return None
         except Exception as e:
             print(f"Error fetching EDHREC data for {card_name}: {e}")
             return None
 
-    def _process_cards(self, cards: List[Dict]) -> Dict[str, Dict]:
+    def _process_cards(self, cards: list[Card]) -> dict[str, Card]:
         """Process downloaded cards into a name-indexed dictionary."""
         processed = {}
         for card in cards:
@@ -113,7 +142,7 @@ class CardDataDownloader:
 
         return processed
 
-    def _is_commander(self, card: Dict) -> bool:
+    def _is_commander(self, card: Card) -> bool:
         """Check if a card can be a commander."""
         # Check if card is legal in commander
         if card.get('legalities', {}).get('commander') != 'legal':
@@ -131,26 +160,72 @@ class CardDataDownloader:
 
         return False
 
-    def _get_commander_type(self, card: Dict) -> str:
+    def _get_commander_type(self, card: Card) -> None:
         """Check if a commander is a vanilla commander, a partner commander, a partner with commander, a background commander, a doctor's companion commander, or a friends forever commander."""
 
-        oracle = card.get('oracle_text', '').lower()
+        oracle = card.get("oracle_text", "").lower()
+        type_line = card.get("type_line", "").lower()
 
         match oracle:
-            case _ if "partner with" in oracle:
-                return "partner_with"
-            case _ if 'partner' in oracle:
-                return  'partner'
-            case _ if 'choose a background' in oracle:
-                return 'background'
-            case _ if 'doctor\'s companion' in oracle:
-                return 'doctors_companion'
-            case _ if 'friends forever' in oracle:
-                return 'friends_forever'
+            case _ if "background" in type_line:
+                self.BACKGROUNDS.append(card["name"])
+            case _ if "time lord doctor" in type_line:
+                self.DOCTORS_COMMANDERS.append(card["name"])
+            case _ if "partner" in oracle:
+                self.PARTNERS.append(card["name"])
+            case _ if "choose a background" in oracle:
+                self.BACKGROUND_COMMANDERS.append(card["name"])
+            case _ if "doctor's companion" in oracle:
+                self.DOCTORS_COMPANIONS.append(card["name"])
+            case _ if "friends forever" in oracle:
+                self.FRIENDS_FOREVER.append(card["name"])
             case _:
-                return 'vanilla'
+                return None
 
-    def _get_commander_name(self, card: Dict) -> str:
+    def _handle_partner_with_commander(self, card: Card) -> dict[str, str]:
+        """Handle commanders that partner with another card."""
+        # Full name of the commander will be the name of the card + the name of the partner
+        oracle_text = card.get("oracle_text", "").lower()
+        return {"name": (oracle_text.split("partner with")[1].split(".")[0].strip())}
+
+    def _handle_background_commander(self, card: Card) -> dict[str, str | list[str]]:
+        """Handle commanders that have a background."""
+        # Since the background is multiple cards, we are returning a Dictionary with the name of a Commander + a list of all the backgrounds, which are cards with the type "background"
+        return {"name": card["name"], "backgrounds": list(self.BACKGROUNDS)}
+
+    def _handle_doctor_companion_commander(
+        self, card: Card
+    ) -> dict[str, str | list[str]]:
+        """Handle commanders that are a doctor's companion."""
+        # Since the doctor's companion is multiple cards, we are returning a Dictionary with the name of a Commander + a list of all the doctor's companions, which are cards with the type "doctor's companion"
+        return {
+            "name": card["name"],
+            "doctor_companions": list(self.DOCTORS_COMPANIONS),
+        }
+
+    def _handle_friends_forever_commander(
+        self, card: Card
+    ) -> dict[str, str | list[str]]:
+        """Handle commanders that are a friends forever."""
+        # Since the friends forever is multiple cards, we are returning a Dictionary with the name of a Commander + a list of all the friends forever, which are cards with the type "friends forever"
+        return {
+            "name": card["name"],
+            "friends_forever": [
+                friend for friend in self.FRIENDS_FOREVER if friend != card["name"]
+            ],
+        }
+
+    def _handle_partner_commander(self, card: Card) -> dict[str, str | list[str]]:
+        """Handle commanders that are a partner."""
+        # Since the partner is multiple cards, we are returning a Dictionary with the name of a Commander + a list of all the partners, which are cards with the type "partner"
+        return {
+            "name": card["name"],
+            "partners": [
+                partner for partner in self.PARTNERS if partner != card["name"]
+            ],
+        }
+
+    def _get_commander_name(self, card: Card) -> str:
         """Get the formatted commander name for EDHREC lookup."""
         name = card['name']
 
@@ -160,7 +235,7 @@ class CardDataDownloader:
                 if (part['object'] == 'related_card' and
                     part['name'] != name and
                     'Legendary' in part['type_line']):
-                    return f"{name} + {part['name']}"
+                    return f"{name}-{part['name']}"
 
         # Handle other partner-type commanders
         oracle_text = card.get('oracle_text', '').lower()
@@ -171,7 +246,7 @@ class CardDataDownloader:
 
         return name
 
-    async def _enrich_with_edhrec_data(self, cards: Dict[str, Dict]) -> Dict[str, Dict]:
+    async def _enrich_with_edhrec_data(self, cards: dict[str, Card]) -> dict[str, Card]:
         """Enrich card data with EDHREC information."""
         # Count total commanders first
         total_commanders = sum(bool(self._is_commander(card))
@@ -187,18 +262,20 @@ class CardDataDownloader:
                     edhrec_data = await self._get_edhrec_data(session, commander_name)
                     if edhrec_data:
                         card['edhrec_data'] = edhrec_data
+                    else:
+                        print(f"Failed to fetch EDHREC data for {commander_name}")
 
                     processed += 1
                     percentage = (processed / total_commanders) * 100
                     print(f"\rProgress: {processed}/{total_commanders} commanders processed ({percentage:.1f}%)", end="")
 
                     # Add delay to respect rate limits
-                    await asyncio.sleep(0.1)
+                    await asyncio.sleep(0.001)
 
         print("\nEDHREC data enrichment complete!")
         return cards
 
-    def _save_cards(self, cards: Dict[str, Dict]):
+    def _save_cards(self, cards: dict[str, Card]):
         """Save processed cards to JSON file."""
         try:
             with open(self.data_file, 'w', encoding='utf-8') as f:
@@ -235,7 +312,7 @@ class CardDataDownloader:
             return
 
         print("Downloading card data...")
-        cards = await self._download_cards(url)
+        cards: list[Card] = await self._download_cards(url)
         if not cards:
             print("Failed to download card data")
             return
@@ -243,7 +320,7 @@ class CardDataDownloader:
         print("Processing cards...")
         processed = self._process_cards(cards)
 
-        processed = await self._enrich_with_edhrec_data(processed)
+        processed: dict[str, Card] = await self._enrich_with_edhrec_data(processed)
 
         print("Saving cards...")
         self._save_cards(processed)

--- a/src/data/card_data_downloader.py
+++ b/src/data/card_data_downloader.py
@@ -7,11 +7,11 @@ from datetime import datetime
 
 class CardDataDownloader:
     """Downloads and processes MTG card data from Scryfall."""
-    
+
     SCRYFALL_BULK_API = "https://api.scryfall.com/bulk-data"
     ORACLE_CARDS = "oracle_cards"
     EDHREC_BASE_URL = "https://json.edhrec.com/pages/commanders"
-    
+
     def __init__(self):
         """Initialize the downloader."""
         # Get the absolute path to the reference directory
@@ -20,7 +20,7 @@ class CardDataDownloader:
         self.data_dir.mkdir(exist_ok=True)
         self.data_file = self.data_dir / 'oracle_cards.json'
         self.last_download_file = self.data_dir / 'last_download.json'
-    
+
     def _update_last_download(self):
         """Update the last download timestamp."""
         try:
@@ -30,7 +30,7 @@ class CardDataDownloader:
             print(f"Updated last download timestamp to {timestamp}")
         except Exception as e:
             print(f"Error updating last download timestamp: {e}")
-    
+
     async def _get_bulk_data_url(self) -> Optional[str]:
         """Get the download URL for oracle cards bulk data."""
         async with aiohttp.ClientSession() as session:
@@ -44,7 +44,7 @@ class CardDataDownloader:
             except Exception as e:
                 print(f"Error getting bulk data URL: {e}")
         return None
-    
+
     async def _download_cards(self, url: str) -> List[Dict]:
         """Download and process card data from Scryfall."""
         async with aiohttp.ClientSession() as session:
@@ -55,7 +55,7 @@ class CardDataDownloader:
             except Exception as e:
                 print(f"Error downloading card data: {e}")
         return []
-    
+
     def _format_name_for_edhrec(self, name: str) -> str:
         """Format card name for EDHREC URL."""
         specials = "àáâãäåèéêëìíîïòóôõöùúûüýÿñç "
@@ -77,7 +77,7 @@ class CardDataDownloader:
         try:
             formatted_name = self._format_name_for_edhrec(card_name)
             url = f"{self.EDHREC_BASE_URL}/{formatted_name}.json"
-            
+
             async with session.get(url) as response:
                 if response.status == 200:
                     data = await response.json()
@@ -108,14 +108,14 @@ class CardDataDownloader:
             # Skip art cards
             if card.get('layout') == 'art_series':
                 continue
-                
+
             # Use the first face for double-faced cards
             if 'card_faces' in card:
                 card = card['card_faces'][0]
-            
+
             # Store the card with its name as the key
             processed[card['name'].lower()] = card
-        
+
         return processed
 
     def _is_commander(self, card: Dict) -> bool:
@@ -126,87 +126,77 @@ class CardDataDownloader:
 
         type_line = card.get('type_line', '').lower()
         oracle_text = card.get('oracle_text', '').lower()
-        
+
         # Check for regular legendary creatures
-        if 'legendary' in type_line and 'creature' in type_line:
+        if 'legendary' in type_line and 'creature' in type_line or 'can be your commander' in oracle_text:
             return True
-            
-        # Check for planeswalkers that can be commanders
-        if 'legendary' in type_line and 'planeswalker' in type_line:
-            if 'can be your commander' in oracle_text:
-                return True
-            
-        # Check for partner commanders
-        if 'legendary' in type_line and 'creature' in type_line:
-            if 'partner' in oracle_text and 'partner with' not in oracle_text:
-                return True
-                
-        # Check for "partner with" commanders
-        if 'legendary' in type_line and 'creature' in type_line:
-            if 'partner with' in oracle_text:
-                return True
-                
-        # Check for background commanders
-        if 'legendary' in type_line and 'creature' in type_line:
-            if 'choose a background' in oracle_text:
-                return True
-                
-        # Check for Friends Forever commanders
-        if 'legendary' in type_line and 'creature' in type_line:
-            if 'friends forever' in oracle_text:
-                return True
-                
-        # Check for Doctor Who commanders
-        if 'legendary' in type_line and 'creature' in type_line:
-            if "doctor's companion" in oracle_text or 'time lord doctor' in type_line:
-                return True
-                
+
         return False
+
+    def _get_commander_type(self, card: Dict) -> str:
+        """Check if a commander is a vanilla commander, a partner commander, a partner with commander, a background commander, a doctor's companion commander, or a friends forever commander."""
+
+        oracle = card.get('oracle_text', '').lower()
+
+        match oracle:
+            case _ if 'partner with' in oracle:
+                return 'partner_with'
+            case _ if 'partner' in oracle:
+                return  'partner'
+            case _ if 'choose a background' in oracle:
+                return 'background'
+            case _ if 'doctor\'s companion' in oracle:
+                return 'doctors_companion'
+            case _ if 'friends forever' in oracle:
+                return 'friends_forever'
+            case _:
+                return 'vanilla'
 
     def _get_commander_name(self, card: Dict) -> str:
         """Get the formatted commander name for EDHREC lookup."""
         name = card['name']
-        
+
         # Handle "partner with" commanders
         if 'all_parts' in card:
             for part in card['all_parts']:
-                if (part['object'] == 'related_card' and 
-                    part['name'] != name and 
+                if (part['object'] == 'related_card' and
+                    part['name'] != name and
                     'Legendary' in part['type_line']):
                     return f"{name} + {part['name']}"
-        
+
         # Handle other partner-type commanders
         oracle_text = card.get('oracle_text', '').lower()
         if any(keyword in oracle_text for keyword in ['partner', 'choose a background', 'friends forever', "doctor's companion"]):
             # For these types, we'll need to handle the partner lookup separately
             # as it requires finding the matching partner card
             return name
-            
+
         return name
 
     async def _enrich_with_edhrec_data(self, cards: Dict[str, Dict]) -> Dict[str, Dict]:
         """Enrich card data with EDHREC information."""
         # Count total commanders first
-        total_commanders = sum(1 for card in cards.values() if self._is_commander(card))
+        total_commanders = sum(bool(self._is_commander(card))
+                           for card in cards.values())
         processed = 0
-        
+
         print(f"\nEnriching {total_commanders} commanders with EDHREC data...")
-        
+
         async with aiohttp.ClientSession() as session:
-            for name, card in cards.items():
+            for card in cards.values():
                 if self._is_commander(card):
                     commander_name = self._get_commander_name(card)
                     edhrec_data = await self._get_edhrec_data(session, commander_name)
                     if edhrec_data:
                         card['edhrec_data'] = edhrec_data
-                    
+
                     processed += 1
                     percentage = (processed / total_commanders) * 100
                     print(f"\rProgress: {processed}/{total_commanders} commanders processed ({percentage:.1f}%)", end="")
-                    
+
                     # Add delay to respect rate limits
                     await asyncio.sleep(0.1)
-        
+
         print("\nEDHREC data enrichment complete!")
         return cards
 
@@ -218,12 +208,12 @@ class CardDataDownloader:
             print(f"Saved {len(cards)} cards to {self.data_file}")
         except Exception as e:
             print(f"Error saving card data: {e}")
-    
+
     def _should_update_data(self) -> bool:
         """Check if the data needs to be updated (older than 1 month)."""
         if not self.last_download_file.exists():
             return True
-            
+
         try:
             with open(self.last_download_file, 'r', encoding='utf-8') as f:
                 data = json.load(f)
@@ -239,30 +229,30 @@ class CardDataDownloader:
         if not self._should_update_data():
             print("Card data is up to date (less than 30 days old)")
             return
-            
+
         print("Getting bulk data URL...")
         url = await self._get_bulk_data_url()
         if not url:
             print("Failed to get bulk data URL")
             return
-        
+
         print("Downloading card data...")
         cards = await self._download_cards(url)
         if not cards:
             print("Failed to download card data")
             return
-        
+
         print("Processing cards...")
         processed = self._process_cards(cards)
-        
+
         processed = await self._enrich_with_edhrec_data(processed)
-        
+
         print("Saving cards...")
         self._save_cards(processed)
-        
+
         print("Updating last download timestamp...")
         self._update_last_download()
-        
+
         print("Done!")
 
 async def main():
@@ -271,4 +261,4 @@ async def main():
     await downloader.download()
 
 if __name__ == "__main__":
-    asyncio.run(main()) 
+    asyncio.run(main())

--- a/tests/test_card_data_downloader.py
+++ b/tests/test_card_data_downloader.py
@@ -1,10 +1,5 @@
 import pytest
-import unicodedata
-from types import SimpleNamespace
-
 from src.data.card_data_downloader import CardDataDownloader
-
-
 
 
 @pytest.mark.parametrize(
@@ -83,7 +78,7 @@ from src.data.card_data_downloader import CardDataDownloader
         "tab_and_newline",
     ],
 )
-def test_format_name_for_edhrec_happy_and_edge_cases(name, expected):
+def test_format_name_for_edhrec_happy_and_edge_cases(name: str, expected: str):
     # Arrange
 
     downloader = CardDataDownloader()
@@ -119,7 +114,7 @@ def test_format_name_for_edhrec_happy_and_edge_cases(name, expected):
         "bytes_input",
     ],
 )
-def test_format_name_for_edhrec_error_cases(name, expected_exception):
+def test_format_name_for_edhrec_error_cases(name: str, expected_exception: type):
     # Arrange
 
     downloader = CardDataDownloader()
@@ -128,3 +123,5 @@ def test_format_name_for_edhrec_error_cases(name, expected_exception):
 
     with pytest.raises(expected_exception):
         downloader._format_name_for_edhrec(name)
+
+

--- a/tests/test_card_data_downloader.py
+++ b/tests/test_card_data_downloader.py
@@ -1,0 +1,130 @@
+import pytest
+import unicodedata
+from types import SimpleNamespace
+
+from src.data.card_data_downloader import CardDataDownloader
+
+
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        # Happy path: simple name
+        ("Sol Ring", "sol-ring"),
+        # Happy path: name with multiple spaces
+        ("Arcane Signet", "arcane-signet"),
+        # Happy path: name with mixed case
+        ("Teferi's Protection", "teferi's-protection"),
+        # Happy path: name with dash
+        ("Sword of Fire and Ice", "sword-of-fire-and-ice"),
+        # Happy path: name with numbers
+        ("Channel 2021", "channel-2021"),
+        # Happy path: name with apostrophe
+        ("Gideon's Intervention", "gideon's-intervention"),
+        # Happy path: name with comma
+        ("Karn, the Great Creator", "karn,-the-great-creator"),
+        # Happy path: name with slash
+        ("Fire // Ice", "fire-//-ice"),
+        # Happy path: name with parentheses
+        ("Nissa, Who Shakes the World (Promo)", "nissa,-who-shakes-the-world-(promo)"),
+        # Happy path: name with non-ASCII (accents)
+        ("Élan Vital", "elan-vital"),
+        # Happy path: name with non-ASCII (umlaut)
+        ("Jötun Grunt", "jotun-grunt"),
+        # Happy path: name with ligature
+        ("Æther Vial", "aether-vial"),
+        # Happy path: name with cedilla
+        ("Façade", "facade"),
+        # Happy path: name with tilde
+        ("Señor of the Wilds", "senor-of-the-wilds"),
+        # Edge case: empty string
+        ("", ""),
+        # Edge case: only spaces
+        ("   ", "---"),
+        # Edge case: only non-ASCII
+        ("ÆÉÖçñ", "aeeocn"),
+        # Edge case: only special characters
+        ("!@#$%^&*()", "!@#$%^&*()"),
+        # Edge case: already formatted
+        ("already-formatted", "already-formatted"),
+        # Edge case: single character
+        ("A", "a"),
+        # Edge case: single non-ASCII character
+        ("É", "e"),
+        # Edge case: whitespace at ends
+        ("  Sol Ring  ", "--sol-ring--"),
+        # Edge case: tab and newline
+        ("Sol\tRing\n", "sol\tring\n"),
+    ],
+    ids=[
+        "simple_name",
+        "multiple_spaces",
+        "mixed_case",
+        "with_dash",
+        "with_numbers",
+        "with_apostrophe",
+        "with_comma",
+        "with_slash",
+        "with_parentheses",
+        "with_accent",
+        "with_umlaut",
+        "with_ligature",
+        "with_cedilla",
+        "with_tilde",
+        "empty_string",
+        "only_spaces",
+        "only_non_ascii",
+        "only_special_chars",
+        "already_formatted",
+        "single_char",
+        "single_non_ascii",
+        "whitespace_ends",
+        "tab_and_newline",
+    ],
+)
+def test_format_name_for_edhrec_happy_and_edge_cases(name, expected):
+    # Arrange
+
+    downloader = CardDataDownloader()
+
+    # Act
+
+    result = downloader._format_name_for_edhrec(name)
+
+    # Assert
+
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "name,expected_exception",
+    [
+        # Error case: None as input
+        (None, TypeError),
+        # Error case: integer as input
+        (123, TypeError),
+        # Error case: list as input
+        (["Sol Ring"], TypeError),
+        # Error case: dict as input
+        ({"name": "Sol Ring"}, TypeError),
+        # Error case: bytes as input
+        (b"Sol Ring", TypeError),
+    ],
+    ids=[
+        "none_input",
+        "int_input",
+        "list_input",
+        "dict_input",
+        "bytes_input",
+    ],
+)
+def test_format_name_for_edhrec_error_cases(name, expected_exception):
+    # Arrange
+
+    downloader = CardDataDownloader()
+
+    # Act & Assert
+
+    with pytest.raises(expected_exception):
+        downloader._format_name_for_edhrec(name)


### PR DESCRIPTION
EDHRec doesn't natively support Average Decks from within the commander url, so I added a constant:

`AVERAGE_DECK_BASE_URL = "https://json.edhrec.com/pages/average-decks"`

This will need to be a secondary API call when doing EDHRec enrichment.

Here's a sample page:

https://json.edhrec.com/pages/average-decks/yorvo-lord-of-garenbrig.json

There's also a redirect that you get when loading certain partners:

https://json.edhrec.com/pages/commanders/ukkima-stalking-shadow-cazur-ruthless-stalker.json

So we can do an API call there to the provided redirect that it offers.

There's some other things missing from EDHRec enrichment, like top 10 cards. Here are the offered headers and tags under cardlists (cardviews are the actual cards recommended there):

```json
{
  "cardlists": [
    {
      "header": "New Cards",
      "tag": "newcards",
      "cardviews": []
    },
    {
      "header": "High Synergy Cards",
      "tag": "highsynergycards",
      "cardviews": []
    },
    {
      "header": "Top Cards",
      "tag": "topcards",
      "cardviews": []
    },
    {
      "header": "Game Changers",
      "tag": "gamechangers",
      "cardviews": []
    },
    {
      "header": "Creatures",
      "tag": "creatures",
      "cardviews": []
    },
    {
      "header": "Instants",
      "tag": "instants",
      "cardviews": []
    },
    {
      "header": "Sorceries",
      "tag": "sorceries",
      "cardviews": []
    },
    {
      "header": "Utility Artifacts",
      "tag": "utilityartifacts",
      "cardviews": []
    },
    {
      "header": "Enchantments",
      "tag": "enchantments",
      "cardviews": []
    },
    {
      "header": "Utility Lands",
      "tag": "utilitylands",
      "cardviews": []
    },
    {
      "header": "Mana Artifacts",
      "tag": "manaartifacts",
      "cardviews": []
    },
    {
      "header": "Lands",
      "tag": "lands"
      "cardviews": []
    }
  ]
}
```

I found the easiest way to grab any of these is just by getting the index. We could set an enum for each of the headers alongside their position to make calling them make more sense. Something like Synergies= 1 in an enum called Header, then call 

```python
"synergies": data_dictionary["cardlists"][Header.Synergies]
```

And so on for the others.


The following code isn't really connected anywhere, but should simplify the logic going forward for finding appropriate matches for partner-type commanders.

```python
    def _get_commander_type(self, card: Card) -> None:
        """Check if a commander is a vanilla commander, a partner commander, a partner with commander, a background commander, a doctor's companion commander, or a friends forever commander."""

        oracle = card.get("oracle_text", "").lower()
        type_line = card.get("type_line", "").lower()

        match oracle:
            case _ if "background" in type_line:
                self.BACKGROUNDS.append(card["name"])
            case _ if "time lord doctor" in type_line:
                self.DOCTORS_COMMANDERS.append(card["name"])
            case _ if "partner" in oracle:
                self.PARTNERS.append(card["name"])
            case _ if "choose a background" in oracle:
                self.BACKGROUND_COMMANDERS.append(card["name"])
            case _ if "doctor's companion" in oracle:
                self.DOCTORS_COMPANIONS.append(card["name"])
            case _ if "friends forever" in oracle:
                self.FRIENDS_FOREVER.append(card["name"])
            case _:
                return None

    def _handle_partner_with_commander(self, card: Card) -> dict[str, str]:
        """Handle commanders that partner with another card."""
        # Full name of the commander will be the name of the card + the name of the partner
        oracle_text = card.get("oracle_text", "").lower()
        return {"name": (oracle_text.split("partner with")[1].split(".")[0].strip())}

    def _handle_background_commander(self, card: Card) -> dict[str, str | list[str]]:
        """Handle commanders that have a background."""
        # Since the background is multiple cards, we are returning a Dictionary with the name of a Commander + a list of all the backgrounds, which are cards with the type "background"
        return {"name": card["name"], "backgrounds": list(self.BACKGROUNDS)}

    def _handle_doctor_companion_commander(
        self, card: Card
    ) -> dict[str, str | list[str]]:
        """Handle commanders that are a doctor's companion."""
        # Since the doctor's companion is multiple cards, we are returning a Dictionary with the name of a Commander + a list of all the doctor's companions, which are cards with the type "doctor's companion"
        return {
            "name": card["name"],
            "doctor_companions": list(self.DOCTORS_COMPANIONS),
        }

    def _handle_friends_forever_commander(
        self, card: Card
    ) -> dict[str, str | list[str]]:
        """Handle commanders that are a friends forever."""
        # Since the friends forever is multiple cards, we are returning a Dictionary with the name of a Commander + a list of all the friends forever, which are cards with the type "friends forever"
        return {
            "name": card["name"],
            "friends_forever": [
                friend for friend in self.FRIENDS_FOREVER if friend != card["name"]
            ],
        }

    def _handle_partner_commander(self, card: Card) -> dict[str, str | list[str]]:
        """Handle commanders that are a partner."""
        # Since the partner is multiple cards, we are returning a Dictionary with the name of a Commander + a list of all the partners, which are cards with the type "partner"
        return {
            "name": card["name"],
            "partners": [
                partner for partner in self.PARTNERS if partner != card["name"]
            ],
        }
```